### PR TITLE
Removed constants & fix minor typos in error messages

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,7 +1,0 @@
-package constants
-
-const (
-	InfraIndexName = "infra-000001"
-	AppIndexName   = "app-000001"
-	AuditIndexName = "audit-000001"
-)

--- a/pkg/controllers/logs/controller.go
+++ b/pkg/controllers/logs/controller.go
@@ -30,27 +30,26 @@ func (controller *LogsController) FilterLogs(gctx *gin.Context) {
 	var params logs.Parameters
 	err := gctx.BindJSON(&params)
 	if err != nil {
-		gctx.JSON(http.StatusInternalServerError, gin.H{ //If Error is not nil and logs is not nil, an internal error might have ocurred
-			"An Error Occurred": err,
+		gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil, an internal server error might have ocurred
+			"An error occurred": err,
 		})
 	}
 	logsList, err := controller.logsProvider.FilterLogs(params)
 
 	if err != nil {
-		if err.Error() == logs.NotFoundError().Error() {
-			//If Error is not nil, and logs is nil, A user error has occurred
+		if err.Error() == logs.NotFoundError().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
 			gctx.JSON(http.StatusBadRequest, gin.H{
-				"Please Check input parameters": err,
+				"Please check the input parameters": err,
 			})
 			return
 		} else {
-			gctx.JSON(http.StatusInternalServerError, gin.H{ //If Error is not nil and logs is not nil, an internal error might have ocurred
-				"An Error Occurred": err,
+			gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil and logs are not nil, implies an internal server error might have ocurred
+				"An error occurred": err,
 			})
 			return
 		}
 	}
 
-	gctx.JSON(http.StatusOK, gin.H{"logs": logsList})
+	gctx.JSON(http.StatusOK, gin.H{"Logs": logsList})
 
 }

--- a/pkg/controllers/logs/controller_test.go
+++ b/pkg/controllers/logs/controller_test.go
@@ -106,7 +106,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"logs": tt.TestData})
+			expected, err = json.Marshal(map[string]interface{}{"Logs": tt.TestData})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}
@@ -124,7 +124,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"logs": tt.TestData})
+			expected, err = json.Marshal(map[string]interface{}{"Logs": tt.TestData})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}
@@ -143,7 +143,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"logs": tt.TestData})
+			expected, err = json.Marshal(map[string]interface{}{"Logs": tt.TestData})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}
@@ -161,7 +161,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"logs": tt.TestData})
+			expected, err = json.Marshal(map[string]interface{}{"Logs": tt.TestData})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}
@@ -183,7 +183,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"logs": tt.TestData})
+			expected, err = json.Marshal(map[string]interface{}{"Logs": tt.TestData})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}
@@ -205,7 +205,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"Please Check input parameters": fmt.Errorf("No logs found!")})
+			expected, err = json.Marshal(map[string]interface{}{"Please check the input parameters": fmt.Errorf("No logs found!")})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}
@@ -224,7 +224,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"Please Check input parameters": fmt.Errorf("No logs found!")})
+			expected, err = json.Marshal(map[string]interface{}{"Please check the input parameters": fmt.Errorf("No logs found!")})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}
@@ -243,7 +243,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 			router.ServeHTTP(rr, req)
 			resp = rr.Body.String()
 			status = rr.Code
-			expected, err = json.Marshal(map[string]interface{}{"Please Check input parameters": fmt.Errorf("No logs found!")})
+			expected, err = json.Marshal(map[string]interface{}{"Please check the input parameters": fmt.Errorf("No logs found!")})
 			if err != nil {
 				t.Errorf("failed to marshal test data. E: %v", err)
 			}

--- a/pkg/elastic/elasticsearch.go
+++ b/pkg/elastic/elasticsearch.go
@@ -139,7 +139,7 @@ func getLogsList(query map[string]interface{}, esClient *elasticsearch.Client, l
 	jsonQuery, err := json.Marshal(query)
 
 	if err != nil {
-		log.Error("An Error occurred while processing the query", zap.Error(err))
+		log.Error("An error occurred while processing the query", zap.Error(err))
 		return nil, err
 	}
 
@@ -189,14 +189,14 @@ func getRelevantLogs(result map[string]interface{}) []string {
 	}
 
 	if len(logsList) == 0 {
-		logsList = append(logsList, "No logs Present or the entry does not exist")
+		logsList = append(logsList, "No logs are present or the entry does not exist")
 	}
 
 	return logsList
 }
 
 func getError(err error) error {
-	fmt.Println("An Error occurred while getting a response: ", err)
-	err = errors.New("An Error occurred while fetching logs")
+	fmt.Println("An error occurred while getting a response: ", err)
+	err = errors.New("An error occurred while fetching logs")
 	return err
 }


### PR DESCRIPTION
 `pkg/constants/constants.go` is not being used now as we are fetching the logs from all the available indices. Therefore, deleted it.
 Fixed some minor typos in error messages to maintain consistency in the messages.