### PR TITLE
add ES_TLS as environment variable

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,12 +4,14 @@ set -eou pipefail
 : ${ES_ADDR:="https://localhost:9200"}
 : ${ES_CERT:="admin-cert"}
 : ${ES_KEY:="admin-key"}
+: ${ES_TLS:= "false"}
 
 if [ "$1" = "log-exploration-api" ]; then
 	exec log-exploration-api \
 		-es-addr=${ES_ADDR} \
 		-es-cert=${ES_CERT} \
-		-es-key=${ES_KEY}
+		-es-key=${ES_KEY} \
+		-es-tls=${ES_TLS}
 fi
 
 exec "$@"

--- a/log-exploration-api-deployment.yaml
+++ b/log-exploration-api-deployment.yaml
@@ -25,6 +25,8 @@ spec:
           value: /etc/openshift/elasticsearch/secret/admin-cert
         - name: ES_KEY
           value: /etc/openshift/elasticsearch/secret/admin-key
+        - name: ES_TLS
+          value: "true"
         ports:
         - containerPort: 8080
         volumeMounts:


### PR DESCRIPTION
added  `ES_TLS` as environment variable. Currently, the default value is set to `false`, and it is required to be `true` in order to connect to the `elasticsearch` pod, since `cert` and `key` need to be passed.