### PR TITLE
Fix populate indices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ image-publish: image
 
 test-e2e:
 	docker-compose up -d
-	@sleep 15
 	chmod +x test/e2e/populate_indices.sh
 	test/e2e/populate_indices.sh
 	go test -v test/e2e/*.go

--- a/test/e2e/populate_indices.sh
+++ b/test/e2e/populate_indices.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 insert_infra() {
-
   curl -X PUT "localhost:9200/infra-000001?pretty" -H 'Content-Type: application/json' -d'
   {
     "settings": {
@@ -33,7 +32,6 @@ insert_infra() {
 }
 
 insert_app() {
-
   curl -X PUT "localhost:9200/app-000001?pretty" -H 'Content-Type: application/json' -d'
   {
     "settings": {
@@ -65,7 +63,6 @@ insert_app() {
 }
 
 insert_audit() {
-
   curl -X PUT "localhost:9200/audit-000001?pretty" -H 'Content-Type: application/json' -d'
   {
     "settings": {
@@ -95,20 +92,46 @@ insert_audit() {
 '
   curl -X POST "localhost:9200/_aliases?pretty" -H 'Content-Type: application/json' -d' { "actions" : [ { "add" : { "index" : "audit-000001", "alias" : "audit" } } ] } '
 }
-populate_es() {
+
+insert_indices() {
+  ES_STATUS=$(curl --silent 'http://localhost:9200/_cluster/health?pretty=true' | jq .status)
+  ES_STATUS_GREEN="\"green\""
+  ES_STATUS_YELLOW="\"yellow\""
+  BASE_URL="http://localhost:9200/"
+  TIME_LIMIT=$((SECONDS+60))
+
+  while [[ $ES_STATUS != $ES_STATUS_GREEN ]] && [[ $ES_STATUS != $ES_STATUS_YELLOW ]]
+  do
+    if [ $SECONDS -gt $TIME_LIMIT ]; then
+      echo "Connection timed out error: Failed to connect to "$BASE_URL
+      docker-compose down -v
+      exit 1
+    fi
+    ES_STATUS=$(curl --request GET -sL --url $BASE_URL'_cluster/health?pretty=true' | jq .status)
+  done
 
   insert_infra
-
   insert_app
-
   insert_audit
+}
+
+check_elasticdump(){
+
+  if ! [ -x "$(command -v elasticdump)" ]; then
+    echo "Error: Elasticdump Not Found."
+    docker-compose down -v
+    exit 1
+  fi
+  populate_es
 
 }
 
-populate_es
-
-# To insert data
-NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/.bin/elasticdump \
+populate_es(){
+  NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump \
     --output=http://localhost:9200 \
     --input=test-logs-mapping.json \
     --type=data
+}
+
+insert_indices
+check_elasticdump

--- a/test/e2e/populate_indices.sh
+++ b/test/e2e/populate_indices.sh
@@ -127,7 +127,7 @@ check_elasticdump(){
 }
 
 populate_es(){
-  NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump \
+  NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/.bin/elasticdump \
     --output=http://localhost:9200 \
     --input=test-logs-mapping.json \
     --type=data


### PR DESCRIPTION
Update `populate-indices.sh` to check if `elasticdump` is installed, and replace `sleep` with HTTP requests to check the status of `ElasticSearch`.