### PR TITLE
fixed testMain in e2e tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.13.0
     container_name: elasticsearch
     environment:
       - xpack.security.enabled=false

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -19,6 +20,7 @@ func TestMain(m *testing.M) {
 
 	appConf := configuration.ParseArgs()
 	esRepository, _ = elastic.NewElasticRepository(log.Named("elasticsearch"), appConf.Elasticsearch)
+	os.Exit(m.Run())
 }
 
 func TestFilterLogs(t *testing.T) {


### PR DESCRIPTION
`TestFilterLogs` method was not being executed because of an issue in `TestMain`.