### PR TITLE
New endpoints Added with unit tests and e2e-tests.

### DIFF
--- a/pkg/controllers/logs/controller.go
+++ b/pkg/controllers/logs/controller.go
@@ -2,6 +2,7 @@ package logscontroller
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/ViaQ/log-exploration-api/pkg/logs"
 	"github.com/gin-gonic/gin"
@@ -13,20 +14,205 @@ type LogsController struct {
 	log          *zap.Logger
 }
 
+func addHeader() gin.HandlerFunc {
+	return func(gctx *gin.Context) {
+		gctx.Header("Access-Control-Allow-Origin", "*")
+		gctx.Next()
+	}
+}
+
 func NewLogsController(log *zap.Logger, logsProvider logs.LogsProvider, router *gin.Engine) *LogsController {
 	controller := &LogsController{
 		log:          log,
 		logsProvider: logsProvider,
 	}
 
+	router.Use(addHeader())
 	r := router.Group("logs")
 	r.GET("/filter", controller.FilterLogs)
+	r.GET("/namespace/:namespace", controller.FilterNamespaceLogs)
+	r.GET("/namespace/:namespace/pod/:podname", controller.FilterPodLogs)
+	r.GET("/namespace/:namespace/pod/:podname/container/:containername", controller.FilterContainerLogs)
+	r.GET("", controller.Logs)
+	r.GET("/logs/namespace/:namespace/:entity/:entity_name", controller.FilterEntityLogs)
+	r.GET("/logs_by_labels/:labels", controller.FilterLabelLogs)
 	return controller
 }
 
+func (controller *LogsController) FilterEntityLogs(gctx *gin.Context) {
+
+	gctx.JSON(http.StatusOK, gin.H{"Logs": "To Be Implemented"})
+
+}
+
+func (controller *LogsController) FilterPodLogs(gctx *gin.Context) {
+
+	var params logs.Parameters
+
+	params.Namespace = gctx.Params.ByName("namespace")
+	params.Podname = gctx.Params.ByName("podname")
+
+	err := gctx.Bind(&params)
+	if err != nil {
+		gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil, an internal server error might have occurred
+			"An error occurred": []string{err.Error()},
+		})
+	}
+
+	logsList, err := controller.logsProvider.FilterPodLogs(params)
+
+	if err != nil {
+		if err.Error() == logs.NotFoundError().Error() || err.Error() == logs.InvalidLimit().Error() || err.Error() == logs.InvalidTimeStamp().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
+			gctx.JSON(http.StatusBadRequest, gin.H{
+				"Please check the input parameters": []string{err.Error()},
+			})
+			return
+		} else {
+			gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil and logs are not nil, implies an internal server error might have ocurred
+				"An error occurred": []string{err.Error()},
+			})
+			return
+		}
+	}
+
+	gctx.JSON(http.StatusOK, gin.H{"Logs": logsList})
+
+}
+func (controller *LogsController) Logs(gctx *gin.Context) {
+
+	var params logs.Parameters
+
+	err := gctx.Bind(&params)
+	if err != nil {
+		gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil, an internal server error might have ocurred
+			"An error occurred": []string{err.Error()},
+		})
+	}
+
+	logsList, err := controller.logsProvider.Logs(params)
+
+	if err != nil {
+		if err.Error() == logs.NotFoundError().Error() || err.Error() == logs.InvalidTimeStamp().Error() || err.Error() == logs.InvalidLimit().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
+			gctx.JSON(http.StatusBadRequest, gin.H{
+				"Please check the input parameters": []string{err.Error()},
+			})
+			return
+		} else {
+			gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil and logs are not nil, implies an internal server error might have ocurred
+				"An error occurred": []string{err.Error()},
+			})
+			return
+		}
+	}
+
+	gctx.JSON(http.StatusOK, gin.H{"Logs": logsList})
+
+}
+
+func (controller *LogsController) FilterNamespaceLogs(gctx *gin.Context) {
+
+	var params logs.Parameters
+
+	params.Namespace = gctx.Params.ByName("namespace")
+
+	err := gctx.Bind(&params)
+	if err != nil {
+		gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil, an internal server error might have ocurred
+			"An error occurred": []string{err.Error()},
+		})
+	}
+
+	logsList, err := controller.logsProvider.FilterNamespaceLogs(params)
+
+	if err != nil {
+		if err.Error() == logs.NotFoundError().Error() || err.Error() == logs.InvalidTimeStamp().Error() || err.Error() == logs.InvalidLimit().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
+			gctx.JSON(http.StatusBadRequest, gin.H{
+				"Please check the input parameters": []string{err.Error()},
+			})
+			return
+		} else {
+			gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil and logs are not nil, implies an internal server error might have ocurred
+				"An error occurred": []string{err.Error()},
+			})
+			return
+		}
+	}
+
+	gctx.JSON(http.StatusOK, gin.H{"Logs": logsList})
+
+}
+
+func (controller *LogsController) FilterContainerLogs(gctx *gin.Context) {
+
+	var params logs.Parameters
+
+	params.Namespace = gctx.Params.ByName("namespace")
+	params.ContainerName = gctx.Params.ByName("containername")
+	params.Podname = gctx.Params.ByName("podname")
+	err := gctx.Bind(&params)
+
+	if err != nil {
+		gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil, an internal server error might have ocurred
+			"An error occurred": []string{err.Error()},
+		})
+	}
+
+	logsList, err := controller.logsProvider.FilterContainerLogs(params)
+
+	if err != nil {
+		if err.Error() == logs.NotFoundError().Error() || err.Error() == logs.InvalidTimeStamp().Error() || err.Error() == logs.InvalidLimit().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
+			gctx.JSON(http.StatusBadRequest, gin.H{
+				"Please check the input parameters": []string{err.Error()},
+			})
+			return
+		} else {
+			gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil and logs are not nil, implies an internal server error might have ocurred
+				"An error occurred": []string{err.Error()},
+			})
+			return
+		}
+	}
+
+	gctx.JSON(http.StatusOK, gin.H{"Logs": logsList})
+
+}
+
+func (controller *LogsController) FilterLabelLogs(gctx *gin.Context) {
+
+	var params logs.Parameters
+
+	labels := gctx.Params.ByName("labels")
+	labelsList := strings.Split(labels, ",") //split labels on "," to obtain a list of individual labels
+	err := gctx.Bind(&params)
+
+	if err != nil {
+		gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil, an internal server error might have ocurred
+			"An error occurred": []string{err.Error()},
+		})
+	}
+
+	logsList, err := controller.logsProvider.FilterLabelLogs(params, labelsList)
+
+	if err != nil {
+		if err.Error() == logs.NotFoundError().Error() || err.Error() == logs.InvalidTimeStamp().Error() || err.Error() == logs.InvalidLimit().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
+			gctx.JSON(http.StatusBadRequest, gin.H{
+				"Please check the input parameters": []string{err.Error()},
+			})
+			return
+		} else {
+			gctx.JSON(http.StatusInternalServerError, gin.H{ //If error is not nil and logs are not nil, implies an internal server error might have ocurred
+				"An error occurred": []string{err.Error()},
+			})
+			return
+		}
+	}
+
+	gctx.JSON(http.StatusOK, gin.H{"Logs": logsList})
+
+}
+
 func (controller *LogsController) FilterLogs(gctx *gin.Context) {
-	gctx.Header("Access-Control-Allow-Origin", "*")
-	gctx.Header("Access-Control-Allow-Headers", "access-control-allow-origin, access-control-allow-headers")
+
 	var params logs.Parameters
 	err := gctx.Bind(&params)
 	if err != nil {
@@ -38,7 +224,7 @@ func (controller *LogsController) FilterLogs(gctx *gin.Context) {
 	logsList, err := controller.logsProvider.FilterLogs(params)
 
 	if err != nil {
-		if err.Error() == logs.NotFoundError().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
+		if err.Error() == logs.NotFoundError().Error() || err.Error() == logs.InvalidTimeStamp().Error() || err.Error() == logs.InvalidLimit().Error() { //If error is not nil, and logs are not nil, implies a user error has occurred
 			gctx.JSON(http.StatusBadRequest, gin.H{
 				"Please check the input parameters": []string{err.Error()},
 			})

--- a/pkg/controllers/logs/controller_test.go
+++ b/pkg/controllers/logs/controller_test.go
@@ -24,7 +24,7 @@ func Test_ControllerFilterLogs(t *testing.T) {
 		Status     int
 	}{
 		{
-			"Filter by no parameters",
+			"Filter by no additional parameters",
 			"app",
 			false,
 			map[string]string{},
@@ -290,7 +290,7 @@ func Test_ControllerFilterLabelLogs(t *testing.T) {
 		Response      map[string][]string
 		Status        int
 	}{{
-		"Filter by container name on no additional query parameters",
+		"Filter label logs",
 		"infra",
 		false,
 		[]string{"app=openshift-kube-scheduler", "revision=8", "scheduler=true"},
@@ -303,7 +303,7 @@ func Test_ControllerFilterLabelLogs(t *testing.T) {
 		200,
 	},
 		{
-			"Filter by time",
+			"Filter by labels and time",
 			"infra",
 			false,
 			[]string{"app=openshift-kube-scheduler", "revision=8", "scheduler=true"},
@@ -412,7 +412,7 @@ func Test_ControllerFilterPodLogs(t *testing.T) {
 		Status     int
 	}{
 		{
-			"Filter by container name on no additional query parameters",
+			"Filter pod logs",
 			"infra",
 			false,
 			map[string]string{"namespace": "openshift-image-registry", "podname": "image-registry-78b76b488f-9lvnn"},
@@ -425,7 +425,7 @@ func Test_ControllerFilterPodLogs(t *testing.T) {
 			200,
 		},
 		{
-			"Filter by logging level on container name",
+			"Filter by logging level",
 			"infra",
 			false,
 			map[string]string{"podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal", "namespace": "openshift-kube-scheduler"},
@@ -539,7 +539,7 @@ func Test_ControllerFilterNamespaceLogs(t *testing.T) {
 		Status     int
 	}{
 		{
-			"Filter by container name on no additional query parameters",
+			"Filter on namespace",
 			"infra",
 			false,
 			map[string]string{"namespace": "openshift-image-registry"},
@@ -552,7 +552,7 @@ func Test_ControllerFilterNamespaceLogs(t *testing.T) {
 			200,
 		},
 		{
-			"Filter by logging level on container name",
+			"Filter by namespace and logging level",
 			"infra",
 			false,
 			map[string]string{"namespace": "openshift-kube-scheduler"},
@@ -562,7 +562,7 @@ func Test_ControllerFilterNamespaceLogs(t *testing.T) {
 			200,
 		},
 		{
-			"Filter by time, and logging level",
+			"Filter by namespace, time, and logging level",
 			"app",
 			false,
 			map[string]string{"namespace": "openshift-kube-scheduler"},

--- a/pkg/controllers/logs/controller_test.go
+++ b/pkg/controllers/logs/controller_test.go
@@ -2,6 +2,7 @@ package logscontroller
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -124,6 +125,631 @@ func Test_ControllerFilterLogs(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 		req, err := http.NewRequest(http.MethodGet, "/logs/filter", nil)
+		q := req.URL.Query()
+		for k, v := range tt.TestParams {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+		if err != nil {
+			t.Errorf("Failed to create HTTP request. E: %v", err)
+		}
+		router.ServeHTTP(rr, req)
+		resp := rr.Body.String()
+		status := rr.Code
+		expected, err := json.Marshal(tt.Response)
+		if err != nil {
+			t.Errorf("failed to marshal test data. E: %v", err)
+		}
+		expectedResp := string(expected)
+		if resp != expectedResp {
+			t.Errorf("expected response to be %s, got %s", expectedResp, resp)
+		}
+		if status != tt.Status {
+			t.Errorf("expected response to be %v, got %v", tt.Status, status)
+		}
+	}
+
+}
+
+func Test_ControllerFilterContainerLogs(t *testing.T) {
+
+	tests := []struct {
+		TestName   string
+		Index      string
+		ShouldFail bool
+		TestParams map[string]string
+		PathParams map[string]string
+		TestData   []string
+		Response   map[string][]string
+		Status     int
+	}{
+		{
+			"Filter by container name on no additional query parameters",
+			"infra",
+			false,
+			map[string]string{},
+			map[string]string{"containername": "registry", "namespace": "openshift-image-registry", "podname": "image-registry-78b76b488f-9lvnn"},
+			[]string{"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry",
+				"test-log-2 namespace_name: openshift-kube-controller-manager, pod_name: image-registry-78b76b488f-bzgqz, container_name: image",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift"},
+			map[string][]string{"Logs": {"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry"}},
+			200,
+		},
+		{
+			"Filter by logging level on container name",
+			"infra",
+			false,
+			map[string]string{"level": "info"},
+			map[string]string{"containername": "openshift-kube-scheduler", "namespace": "openshift-kube-scheduler", "podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"}},
+			200,
+		},
+		{
+			"Filter by time, and logging level",
+			"app",
+			false,
+			map[string]string{
+				"starttime":  "2021-03-17T14:22:20+05:30",
+				"finishtime": "2021-03-17T14:23:20+05:30",
+				"level":      "warn",
+			},
+			map[string]string{"containername": "openshift", "namespace": "openshift-kube-scheduler", "podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"}},
+			200,
+		},
+		{
+			"Invalid parameters",
+			"audit",
+			false,
+			map[string]string{},
+			map[string]string{"containername": "dummy_container", "namespace": "dummy_namespace", "podname": "dummy_podname"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"Invalid timestamp",
+			"infra",
+			false,
+			map[string]string{
+				"starttime":  "hey",
+				"finishtime": "hey",
+			},
+			map[string]string{"containername": "openshift-kube", "namespace": "openshift-kube", "podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"No logs in the given time interval",
+			"infra",
+			false,
+			map[string]string{
+				"starttime":  "2022-03-17T14:22:20+05:30",
+				"finishtime": "2022-03-17T14:23:20+05:30",
+			},
+			map[string]string{"containername": "openshift-kube", "namespace": "openshift-kube-scheduler", "podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+	}
+
+	provider := elastic.NewMockedElastisearchProvider()
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	NewLogsController(zap.L(), provider, router)
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		logTime, _ := time.Parse(time.RFC3339Nano, "2021-03-17T14:22:40+05:30")
+		provider.Cleanup()
+		provider.PutDataAtTime(logTime, tt.Index, tt.TestData)
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/logs/namespace/"+tt.PathParams["namespace"]+"/pod/"+tt.PathParams["podname"]+"/container/"+tt.PathParams["containername"], nil)
+		q := req.URL.Query()
+		for k, v := range tt.TestParams {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+		if err != nil {
+			t.Errorf("Failed to create HTTP request. E: %v", err)
+		}
+		fmt.Println(req.URL.String())
+		router.ServeHTTP(rr, req)
+		resp := rr.Body.String()
+		status := rr.Code
+		expected, err := json.Marshal(tt.Response)
+		if err != nil {
+			t.Errorf("failed to marshal test data. E: %v", err)
+		}
+		expectedResp := string(expected)
+		if resp != expectedResp {
+			t.Errorf("expected response to be %s, got %s", expectedResp, resp)
+		}
+		if status != tt.Status {
+			t.Errorf("expected response to be %v, got %v", tt.Status, status)
+		}
+	}
+
+}
+
+func Test_ControllerFilterLabelLogs(t *testing.T) {
+
+	tests := []struct {
+		TestName      string
+		Index         string
+		ShouldFail    bool
+		LabelsList    []string
+		UrlPathLabels string
+		TestParams    map[string]string
+		TestData      []string
+		Response      map[string][]string
+		Status        int
+	}{{
+		"Filter by container name on no additional query parameters",
+		"infra",
+		false,
+		[]string{"app=openshift-kube-scheduler", "revision=8", "scheduler=true"},
+		"app=openshift-kube-scheduler,revision=8,scheduler=true",
+		map[string]string{},
+		[]string{"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry, flat_labels: app=openshift-kube-scheduler,revision=8,scheduler=true",
+			"test-log-2 namespace_name: openshift-kube-controller-manager, pod_name: image-registry-78b76b488f-bzgqz, container_name: image, flat_labels: app=openshift-kube-scheduler,revision=8",
+			"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift, flat_labels: app=cluster-version-operator"},
+		map[string][]string{"Logs": {"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry, flat_labels: app=openshift-kube-scheduler,revision=8,scheduler=true"}},
+		200,
+	},
+		{
+			"Filter by time",
+			"infra",
+			false,
+			[]string{"app=openshift-kube-scheduler", "revision=8", "scheduler=true"},
+			"app=openshift-kube-scheduler,revision=8,scheduler=true",
+			map[string]string{"starttime": "2021-03-17T14:22:20+05:30", "finishtime": "2021-03-17T14:23:20+05:30"},
+			[]string{"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry, flat_labels: app=openshift-kube-scheduler,revision=8,scheduler=true",
+				"test-log-2 namespace_name: openshift-kube-controller-manager, pod_name: image-registry-78b76b488f-bzgqz, container_name: image, flat_labels: app=openshift-kube-scheduler,revision=8",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift, flat_labels: app=cluster-version-operator"},
+			map[string][]string{"Logs": {"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry, flat_labels: app=openshift-kube-scheduler,revision=8,scheduler=true"}},
+			200,
+		},
+		{
+			"Filter by labels and logging level",
+			"audit",
+			false,
+			[]string{"app=openshift-kube-scheduler", "revision=8", "scheduler=true"},
+			"app=openshift-kube-scheduler,revision=8,scheduler=true",
+			map[string]string{
+				"level": "info",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, flat_labels: app=openshift-kube-scheduler, revision=8, scheduler=true"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, flat_labels: app=openshift-kube-scheduler, revision=8, scheduler=true"}},
+			200,
+		},
+		{
+			"Invalid timestamp",
+			"infra",
+			false,
+			[]string{"app=openshift-kube-scheduler", "revision=8", "scheduler=true"},
+			"app=openshift-kube-scheduler,revision=8,scheduler=true",
+			map[string]string{
+				"starttime":  "hey",
+				"finishtime": "hey",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, flat_labels: app=openshift-kube-scheduler,revision=8,scheduler=true"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"No logs in the given time interval",
+			"infra",
+			false,
+			[]string{"app=openshift-cluster-version"},
+			"app=openshift-cluster-version",
+			map[string]string{
+				"starttime":  "2022-03-17T14:22:20+05:30",
+				"finishtime": "2022-03-17T14:23:20+05:30",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, flat_labels: app=openshift-cluster-version"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+	}
+
+	provider := elastic.NewMockedElastisearchProvider()
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	NewLogsController(zap.L(), provider, router)
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		logTime, _ := time.Parse(time.RFC3339Nano, "2021-03-17T14:22:40+05:30")
+		provider.Cleanup()
+		provider.PutDataAtTime(logTime, tt.Index, tt.TestData)
+
+		rr := httptest.NewRecorder()
+		Url := "/logs/logs_by_labels/" + tt.UrlPathLabels
+
+		req, err := http.NewRequest(http.MethodGet, Url, nil)
+		q := req.URL.Query()
+		for k, v := range tt.TestParams {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+		if err != nil {
+			t.Errorf("Failed to create HTTP request. E: %v", err)
+		}
+		router.ServeHTTP(rr, req)
+		resp := rr.Body.String()
+		status := rr.Code
+		expected, err := json.Marshal(tt.Response)
+		if err != nil {
+			t.Errorf("failed to marshal test data. E: %v", err)
+		}
+		expectedResp := string(expected)
+		if resp != expectedResp {
+			t.Errorf("expected response to be %s, got %s", expectedResp, resp)
+		}
+		if status != tt.Status {
+			t.Errorf("expected response to be %v, got %v", tt.Status, status)
+		}
+	}
+
+}
+
+func Test_ControllerFilterPodLogs(t *testing.T) {
+
+	tests := []struct {
+		TestName   string
+		Index      string
+		ShouldFail bool
+		PathParams map[string]string
+		TestParams map[string]string
+		TestData   []string
+		Response   map[string][]string
+		Status     int
+	}{
+		{
+			"Filter by container name on no additional query parameters",
+			"infra",
+			false,
+			map[string]string{"namespace": "openshift-image-registry", "podname": "image-registry-78b76b488f-9lvnn"},
+			map[string]string{},
+			[]string{"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry",
+				"test-log-2 namespace_name: openshift-kube-controller-manager, pod_name: image-registry-78b76b488f-bzgqz, container_name: image",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift"},
+			map[string][]string{"Logs": {"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift"}},
+			200,
+		},
+		{
+			"Filter by logging level on container name",
+			"infra",
+			false,
+			map[string]string{"podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal", "namespace": "openshift-kube-scheduler"},
+			map[string]string{"level": "info"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"}},
+			200,
+		},
+		{
+			"Invalid Path Parameters",
+			"infra",
+			false,
+			map[string]string{"podname": "cluster-kube-scheduler-ip-10-0-157-165.ec2.internal", "namespace": "openshift-kube-scheduler"},
+			map[string]string{"level": "info"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"Filter by time, and logging level",
+			"app",
+			false,
+			map[string]string{"podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal", "namespace": "openshift-kube-scheduler"},
+			map[string]string{
+				"starttime":  "2021-03-17T14:22:20+05:30",
+				"finishtime": "2021-03-17T14:23:20+05:30",
+				"level":      "warn",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"}},
+			200,
+		},
+		{
+			"Invalid timestamp",
+			"infra",
+			false,
+			map[string]string{"podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal", "namespace": "openshift-kube-scheduler"},
+			map[string]string{
+				"starttime":  "hey",
+				"finishtime": "hey",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"No logs in the given time interval",
+			"infra",
+			false,
+			map[string]string{"podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal", "namespace": "openshift-kube-scheduler"},
+			map[string]string{
+				"starttime":  "2022-03-17T14:22:20+05:30",
+				"finishtime": "2022-03-17T14:23:20+05:30",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+	}
+
+	provider := elastic.NewMockedElastisearchProvider()
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	NewLogsController(zap.L(), provider, router)
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		logTime, _ := time.Parse(time.RFC3339Nano, "2021-03-17T14:22:40+05:30")
+		provider.Cleanup()
+		provider.PutDataAtTime(logTime, tt.Index, tt.TestData)
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/logs/namespace/"+tt.PathParams["namespace"]+"/pod/"+tt.PathParams["podname"], nil)
+		q := req.URL.Query()
+		for k, v := range tt.TestParams {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+		if err != nil {
+			t.Errorf("Failed to create HTTP request. E: %v", err)
+		}
+		fmt.Println(req.URL.String())
+		router.ServeHTTP(rr, req)
+		resp := rr.Body.String()
+		status := rr.Code
+		expected, err := json.Marshal(tt.Response)
+		if err != nil {
+			t.Errorf("failed to marshal test data. E: %v", err)
+		}
+		expectedResp := string(expected)
+		if resp != expectedResp {
+			t.Errorf("expected response to be %s, got %s", expectedResp, resp)
+		}
+		if status != tt.Status {
+			t.Errorf("expected response to be %v, got %v", tt.Status, status)
+		}
+	}
+
+}
+
+func Test_ControllerFilterNamespaceLogs(t *testing.T) {
+
+	tests := []struct {
+		TestName   string
+		Index      string
+		ShouldFail bool
+		PathParams map[string]string
+		TestParams map[string]string
+		TestData   []string
+		Response   map[string][]string
+		Status     int
+	}{
+		{
+			"Filter by container name on no additional query parameters",
+			"infra",
+			false,
+			map[string]string{"namespace": "openshift-image-registry"},
+			map[string]string{},
+			[]string{"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry",
+				"test-log-2 namespace_name: openshift-kube-controller-manager, pod_name: image-registry-78b76b488f-bzgqz, container_name: image",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift"},
+			map[string][]string{"Logs": {"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift"}},
+			200,
+		},
+		{
+			"Filter by logging level on container name",
+			"infra",
+			false,
+			map[string]string{"namespace": "openshift-kube-scheduler"},
+			map[string]string{"level": "info"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"}},
+			200,
+		},
+		{
+			"Filter by time, and logging level",
+			"app",
+			false,
+			map[string]string{"namespace": "openshift-kube-scheduler"},
+			map[string]string{
+				"starttime":  "2021-03-17T14:22:20+05:30",
+				"finishtime": "2021-03-17T14:23:20+05:30",
+				"level":      "warn",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"}},
+			200,
+		},
+		{
+			"Invalid Namespace",
+			"audit",
+			false,
+			map[string]string{"namespace": "cluster-scheduler"},
+			map[string]string{},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"Invalid timestamp",
+			"infra",
+			false,
+			map[string]string{"namespace": "openshift-kube-scheduler"},
+			map[string]string{
+				"starttime":  "hey",
+				"finishtime": "hey",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"No logs in the given time interval",
+			"infra",
+			false,
+			map[string]string{"namespace": "openshift-kube-scheduler"},
+			map[string]string{
+				"starttime":  "2022-03-17T14:22:20+05:30",
+				"finishtime": "2022-03-17T14:23:20+05:30",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+	}
+
+	provider := elastic.NewMockedElastisearchProvider()
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	NewLogsController(zap.L(), provider, router)
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		logTime, _ := time.Parse(time.RFC3339Nano, "2021-03-17T14:22:40+05:30")
+		provider.Cleanup()
+		provider.PutDataAtTime(logTime, tt.Index, tt.TestData)
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/logs/namespace/"+tt.PathParams["namespace"], nil)
+		q := req.URL.Query()
+		for k, v := range tt.TestParams {
+			q.Add(k, v)
+		}
+		req.URL.RawQuery = q.Encode()
+		if err != nil {
+			t.Errorf("Failed to create HTTP request. E: %v", err)
+		}
+		fmt.Println(req.URL.String())
+		router.ServeHTTP(rr, req)
+		resp := rr.Body.String()
+		status := rr.Code
+		expected, err := json.Marshal(tt.Response)
+		if err != nil {
+			t.Errorf("failed to marshal test data. E: %v", err)
+		}
+		expectedResp := string(expected)
+		if resp != expectedResp {
+			t.Errorf("expected response to be %s, got %s", expectedResp, resp)
+		}
+		if status != tt.Status {
+			t.Errorf("expected response to be %v, got %v", tt.Status, status)
+		}
+	}
+
+}
+
+func Test_ControllerLogs(t *testing.T) {
+
+	tests := []struct {
+		TestName   string
+		Index      string
+		ShouldFail bool
+		TestParams map[string]string
+		TestData   []string
+		Response   map[string][]string
+		Status     int
+	}{
+		{
+			"Filter no additional query parameters [Get all logs]",
+			"infra",
+			false,
+			map[string]string{},
+			[]string{"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry",
+				"test-log-2 namespace_name: openshift-kube-controller-manager, pod_name: image-registry-78b76b488f-bzgqz, container_name: image",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift"},
+			map[string][]string{"Logs": {"test-log-1 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: registry",
+				"test-log-2 namespace_name: openshift-kube-controller-manager, pod_name: image-registry-78b76b488f-bzgqz, container_name: image",
+				"test-log-3 namespace_name: openshift-image-registry, pod_name: image-registry-78b76b488f-9lvnn, container_name: openshift"}},
+			200,
+		},
+		{
+			"Filter by logging level",
+			"infra",
+			false,
+			map[string]string{"level": "info"},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler",
+				"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: warn, container_name: openshift-kube-scheduler"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, level: info, container_name: openshift-kube-scheduler"}},
+			200,
+		},
+		{
+			"Filter by time, and logging level",
+			"app",
+			false,
+			map[string]string{
+				"starttime":  "2021-03-17T14:22:20+05:30",
+				"finishtime": "2021-03-17T14:23:20+05:30",
+				"level":      "warn",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"},
+			map[string][]string{"Logs": {"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift, level: warn"}},
+			200,
+		},
+		{
+			"Invalid timestamp",
+			"infra",
+			false,
+			map[string]string{
+				"starttime":  "hey",
+				"finishtime": "hey",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"Invalid Logging level",
+			"infra",
+			false,
+			map[string]string{
+				"level": "invalid-level",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+		{
+			"No logs in the given time interval",
+			"infra",
+			false,
+			map[string]string{
+				"starttime":  "2022-03-17T14:22:20+05:30",
+				"finishtime": "2022-03-17T14:23:20+05:30",
+			},
+			[]string{"test-log pod_name: openshift-kube-scheduler-ip-10-0-157-165.ec2.internal, namespace_name: openshift-kube-scheduler, container_name: openshift-kube"},
+			map[string][]string{"Please check the input parameters": {"Not Found Error"}},
+			400,
+		},
+	}
+
+	provider := elastic.NewMockedElastisearchProvider()
+	gin.SetMode(gin.TestMode)
+	router := gin.Default()
+	NewLogsController(zap.L(), provider, router)
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		logTime, _ := time.Parse(time.RFC3339Nano, "2021-03-17T14:22:40+05:30")
+		provider.Cleanup()
+		provider.PutDataAtTime(logTime, tt.Index, tt.TestData)
+
+		rr := httptest.NewRecorder()
+		req, err := http.NewRequest(http.MethodGet, "/logs", nil)
 		q := req.URL.Query()
 		for k, v := range tt.TestParams {
 			q.Add(k, v)

--- a/pkg/elastic/params_check.go
+++ b/pkg/elastic/params_check.go
@@ -1,0 +1,31 @@
+package elastic
+
+import (
+	"github.com/ViaQ/log-exploration-api/pkg/logs"
+	"strconv"
+	"time"
+)
+
+func validateParams(params logs.Parameters) error {
+
+	var err error
+	if len(params.StartTime) > 0 && len(params.FinishTime) > 0 {
+
+		_, err = time.Parse(time.RFC3339Nano, params.StartTime)
+		if err != nil {
+			return logs.InvalidTimeStamp()
+		}
+		_, err = time.Parse(time.RFC3339Nano, params.FinishTime)
+		if err != nil {
+			return logs.InvalidTimeStamp()
+		}
+	}
+	if len(params.MaxLogs) > 0 {
+		maxLogs, err := strconv.Atoi(params.MaxLogs)
+		if err != nil || maxLogs < 0 {
+			return logs.InvalidLimit()
+		}
+	}
+
+	return nil
+}

--- a/pkg/logs/errors.go
+++ b/pkg/logs/errors.go
@@ -5,3 +5,9 @@ import "errors"
 func NotFoundError() error {
 	return errors.New("Not Found Error")
 }
+func InvalidTimeStamp() error {
+	return errors.New("incorrect time format: Please Enter Time in the following format YYYY-MM-DD'T'HH:mm:ss.SSS[TIMEZONE ex:'Z']")
+}
+func InvalidLimit() error {
+	return errors.New("invalid \"maxlogs\" value, an integer between 0 to 1000 is required")
+}

--- a/pkg/logs/params.go
+++ b/pkg/logs/params.go
@@ -8,4 +8,5 @@ type Parameters struct {
 	FinishTime string `form:"finishtime"`
 	Level      string `form:"level"`
 	MaxLogs    string `form:"maxlogs"`
+	ContainerName string `form:"containername"`
 }

--- a/pkg/logs/provider.go
+++ b/pkg/logs/provider.go
@@ -2,4 +2,9 @@ package logs
 
 type LogsProvider interface {
 	FilterLogs(params Parameters) ([]string, error)
+	FilterContainerLogs(params Parameters) ([]string, error)
+	FilterLabelLogs(params Parameters,labelList []string) ([]string,error)
+	FilterNamespaceLogs(params Parameters) ([]string,error)
+	FilterPodLogs(params Parameters) ([]string,error)
+	Logs(params Parameters) ([]string,error)
 }

--- a/test/e2e/elasticsearch_test.go
+++ b/test/e2e/elasticsearch_test.go
@@ -1,7 +1,6 @@
 package e2e
 
 import (
-	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -13,14 +12,433 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+
 var esRepository logs.LogsProvider
 
 func TestMain(m *testing.M) {
 	log, _ := initCustomZapLogger("info")
 
 	appConf := configuration.ParseArgs()
-	esRepository, _ = elastic.NewElasticRepository(log.Named("elasticsearch"), appConf.Elasticsearch)
+	esRepository,_ = elastic.NewElasticRepository(log.Named("elasticsearch"), appConf.Elasticsearch)
 	os.Exit(m.Run())
+}
+
+func TestFilterPodLogs(t *testing.T) {
+
+	tests := []struct {
+		TestName     string
+		ShouldFail   bool
+		TestParams   map[string]string
+		TestError    error
+		TestKeywords []string
+	}{
+		{
+			"Filter Pod Logs",
+			false,
+			map[string]string{"Podname":"openshift-kube-scheduler-ip-10-0-157-165.ec2.internal"},
+			nil,
+			[]string{"openshift-kube-scheduler-ip-10-0-157-165.ec2.internal"},
+		},
+		{
+			"Filter Pod logs in a given time range",
+			false,
+			map[string]string{"StartTime": "2021-03-18T06:41:51.83503Z", "FinishTime": "2021-03-18T06:41:51.83503Z","Podname":"openshift-kube-scheduler-ip-10-0-157-165.ec2.internal"},
+			nil,
+			[]string{"timestamp", "2021-03-18T06:41:51"},
+		},
+		{
+			"Filter Pod logs by Logging level",
+			false,
+			map[string]string{
+				"Podname": "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal",
+				"level": "unknown",
+			},
+			nil,
+			[]string{"infra-000001", "openshift-kube-scheduler-ip-10-0-157-165.ec2.internal", "unknown"},
+		},
+		{
+			"Invalid Podname, or Podname for which no logs exist",
+			false,
+			map[string]string{
+				"Podname":   "hello",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Invalid timestamp",
+			false,
+			map[string]string{
+				"StartTime":  "hey",
+				"FinishTime": "hey",
+			},
+			logs.InvalidTimeStamp(),
+			[]string{},
+		},
+		{
+			"No logs in the given time interval for a particular pod",
+			false,
+			map[string]string{
+				"Podname":"openshift-kube-scheduler-ip-10-0-157-165.ec2.internal",
+				"StartTime":  "2022-03-17T14:22:20+05:30",
+				"FinishTime": "2022-03-17T14:23:20+05:30",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Negative Limit value",
+			false,
+			map[string]string{
+				"Maxlogs":  "-2",
+			},
+			logs.InvalidLimit(),
+			[]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		repository := esRepository
+		params := logs.Parameters{}
+
+		addParams(&params,tt.TestParams)
+
+		logList, err := repository.FilterPodLogs(params)
+		if err == nil && tt.TestError != nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError == nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError != nil && err.Error() != tt.TestError.Error() {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if logList != nil {
+			if strings.Contains(tt.TestName, "Invalid") || strings.Contains(tt.TestName, "No logs") {
+				if !strings.Contains(logList[0], "No logs are present or the entry does not exist") {
+					t.Errorf("Expected response: No logs are present or the entry does not exist")
+				}
+			} else {
+				for _, keyword := range tt.TestKeywords {
+					if !strings.Contains(logList[0], keyword) {
+						t.Errorf("Invalid logs found!")
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestFilterLogsByLabel(t *testing.T) {
+
+	tests := []struct {
+		TestName     string
+		ShouldFail   bool
+		LabelList []string
+		TestParams   map[string]string
+		TestError    error
+		TestKeywords []string
+	}{
+		{
+			"Filter Logs for a set of labels",
+			false,
+			[]string{"app=openshift-kube-scheduler","revision=8","scheduler=true"},
+			map[string]string{},
+			nil,
+			[]string{"app=openshift-kube-scheduler","revision=8","scheduler=true"},
+		},
+		{
+			"Filter Logs for a set of labels in a given time range",
+			false,
+			[]string{"app=openshift-kube-scheduler","revision=8","scheduler=true"},
+			map[string]string{"StartTime": "2021-03-18T06:41:51.83503Z", "FinishTime": "2021-03-18T06:41:51.83503Z"},
+			nil,
+			[]string{"timestamp", "2021-03-18T06:41:51.835","app=openshift-kube-scheduler","revision=8","scheduler=true"},
+		},
+		{
+			"Filter logs by Labels, and Logging level",
+			false,
+			[]string{"app=openshift-kube-scheduler","revision=8","scheduler=true"},
+			map[string]string{
+				"level": "unknown",
+			},
+			nil,
+			[]string{"app=openshift-kube-scheduler","revision=8","scheduler=true","unknown"},
+		},
+		{
+			"Invalid Labels, or Labels for which no logs exist",
+			false,
+			[]string{"app=dummy"},
+			map[string]string{
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Invalid timestamp",
+			false,
+			[]string{"app=openshift-kube-scheduler","revision=8"},
+			map[string]string{
+				"StartTime":  "hey",
+				"FinishTime": "hey",
+			},
+			logs.InvalidTimeStamp(),
+			[]string{},
+		},
+		{
+			"No logs in the given time interval for a set of labels",
+			false,
+			[]string{"app=openshift-kube-scheduler","revision=8","scheduler=true"},
+			map[string]string{
+				"StartTime":  "2022-03-17T14:22:20Z",
+				"FinishTime": "2022-03-17T14:23:20Z",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Negative Limit value",
+			false,
+			[]string{},
+			map[string]string{
+				"Maxlogs":  "-2",
+			},
+			logs.InvalidLimit(),
+			[]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		repository := esRepository
+		params := logs.Parameters{}
+
+		addParams(&params,tt.TestParams)
+
+		logList, err := repository.FilterLabelLogs(params,tt.LabelList)
+		if err == nil && tt.TestError != nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError == nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError != nil && err.Error() != tt.TestError.Error() {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if logList != nil {
+			if strings.Contains(tt.TestName, "Invalid") || strings.Contains(tt.TestName, "No logs") {
+				if !strings.Contains(logList[0], "No logs are present or the entry does not exist") {
+					t.Errorf("Expected response: No logs are present or the entry does not exist")
+				}
+			} else {
+				for _, keyword := range tt.TestKeywords {
+					if !strings.Contains(logList[0], keyword) {
+						t.Errorf("Invalid logs found!")
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestFilterNamespaceLogs(t *testing.T) {
+	tests := []struct {
+		TestName     string
+		ShouldFail   bool
+		TestParams   map[string]string
+		TestError    error
+		TestKeywords []string
+	}{
+		{
+			"Filter by namespace",
+			false,
+			map[string]string{"Namespace":"openshift-kube-scheduler"},
+			nil,
+			[]string{"openshift-kube-scheduler"},
+		},
+		{
+			"Filter logs of a Namespace, between a given time range",
+			false,
+			map[string]string{
+				"Namespace":  "openshift-kube-scheduler",
+				"StartTime":  "2021-03-18T06:41:51.83503Z",
+				"FinishTime": "2021-03-18T06:41:51.83503Z",
+			},
+			nil,
+			[]string{"infra-000001", "openshift-kube-scheduler", "2021-03-18T06:41:51.835"},
+		},
+		{
+			"Invalid parameters - Invalid Namespace",
+			false,
+			map[string]string{
+				"Namespace": "world",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Invalid timestamp",
+			false,
+			map[string]string{
+				"Namespace":"openshift-kube-scheduler",
+				"StartTime":  "hey",
+				"FinishTime": "hey",
+			},
+			logs.InvalidTimeStamp(),
+			[]string{},
+		},
+		{
+			"No logs in the given time interval for a namespace",
+			false,
+			map[string]string{
+				"Namespace":"openshift-kube-scheduler",
+				"StartTime":  "2022-03-17T14:22:20Z",
+				"FinishTime": "2022-03-17T14:23:20Z",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Negative maxlogs - Incorrect Limit Parameter",
+			false,
+			map[string]string{
+				"Namespace":"openshift-kube-scheduler",
+				"Maxlogs":  "-2",
+			},
+			logs.InvalidLimit(),
+			[]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		repository := esRepository
+		params := logs.Parameters{}
+		addParams(&params,tt.TestParams)
+
+		logList, err := repository.FilterNamespaceLogs(params)
+
+		if err == nil && tt.TestError != nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError == nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError != nil && err.Error() != tt.TestError.Error() {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if logList != nil {
+			if strings.Contains(tt.TestName, "Invalid") || strings.Contains(tt.TestName, "No logs") {
+				if !strings.Contains(logList[0], "No logs are present or the entry does not exist") {
+					t.Errorf("Expected response: No logs are present or the entry does not exist")
+				}
+			} else {
+				for _, keyword := range tt.TestKeywords {
+					if !strings.Contains(logList[0], keyword) {
+						t.Errorf("Invalid logs found!")
+					}
+				}
+			}
+		}
+	}
+}
+
+func TestFilterContainerLogs(t *testing.T) {
+	tests := []struct {
+		TestName     string
+		ShouldFail   bool
+		TestParams   map[string]string
+		TestError    error
+		TestKeywords []string
+	}{
+		{
+			"Filter, and Fetch logs for a container in a pod for a given namespace",
+			false,
+			map[string]string{"ContainerName":"kube-scheduler-cert-syncer","Namespace":"openshift-kube-scheduler","Podname":"openshift-kube-scheduler-ip-10-0-162-9.ec2.internal"},
+			nil,
+			[]string{"kube-scheduler-cert-syncer","openshift-kube-scheduler"},
+		},
+		{
+			"Filter container logs in a given time range",
+			false,
+			map[string]string{
+				"ContainerName":    "kube-scheduler-cert-syncer",
+				"Podname":"openshift-kube-scheduler-ip-10-0-162-9.ec2.internal",
+				"Namespace":  "openshift-kube-scheduler",
+				"StartTime":  "2021-03-18T06:41:15.54171Z",
+				"FinishTime": "2021-03-18T06:41:18.54171Z",
+			},
+			nil,
+			[]string{"openshift-kube-scheduler", "kube-scheduler-cert-syncer", "2021-03-18T06:41"},
+		},
+		{
+			"Invalid namespace and container",
+			false,
+			map[string]string{
+				"ContainerName":   "hello",
+				"Namespace": "world",
+				"Podname":"openshift-kube-scheduler-ip-10-0-162-9.ec2.internal",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Invalid timestamp",
+			false,
+			map[string]string{
+				"Namespace":"openshift-kube-scheduler",
+				"Podname":"openshift-kube-scheduler-ip-10-0-162-9.ec2.internal",
+				"ContainerName":"kube-scheduler-cert-syncer",
+				"StartTime":  "hey",
+				"FinishTime": "hey",
+			},
+			logs.InvalidTimeStamp(),
+			[]string{},
+		},
+		{
+			"No logs in the given time interval",
+			false,
+			map[string]string{
+				"Namespace":"openshift-image-registry",
+				"Podname":"image-registry-78b76b488f-bzgqz",
+				"ContainerName":"registry",
+				"StartTime":  "2022-03-17T14:22:20Z",
+				"FinishTime": "2022-03-17T14:23:20Z",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Negative maxlogs",
+			false,
+			map[string]string{
+				"Maxlogs":  "-2",
+			},
+			logs.InvalidLimit(),
+			[]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		repository := esRepository
+		params := logs.Parameters{}
+		addParams(&params,tt.TestParams)
+		logList, err := repository.FilterContainerLogs(params)
+		if err == nil && tt.TestError != nil {
+			t.Errorf("Expected error is: %v, found: %v", tt.TestError, err)
+		} else if err != nil && tt.TestError == nil {
+			t.Errorf("Expected error is: %v, found: %v", tt.TestError, err)
+		} else if err != nil && tt.TestError != nil && err.Error() != tt.TestError.Error() {
+			t.Errorf("Expected error is: %v, found: %v", tt.TestError, err)
+		} else if logList != nil {
+			if strings.Contains(tt.TestName, "Invalid") || strings.Contains(tt.TestName, "No logs") {
+				if !strings.Contains(logList[0], "No logs are present or the entry does not exist") {
+					t.Errorf("Expected response: No logs are present or the entry does not exist")
+				}
+			} else {
+				for _, keyword := range tt.TestKeywords {
+					if !strings.Contains(logList[0], keyword) {
+						t.Errorf("Invalid logs found!")
+						break
+					}
+				}
+			}
+		}
+	}
+
 }
 
 func TestFilterLogs(t *testing.T) {
@@ -89,15 +507,15 @@ func TestFilterLogs(t *testing.T) {
 				"StartTime":  "hey",
 				"FinishTime": "hey",
 			},
-			errors.New("incorrect time format: Please Enter Start Time in the following format YYYY-MM-DDTHH:MM:SS[TIMEZONE ex:+00:00]"),
+			logs.InvalidTimeStamp(),
 			[]string{},
 		},
 		{
 			"No logs in the given time interval",
 			false,
 			map[string]string{
-				"StartTime":  "2022-03-17T14:22:20+05:30",
-				"FinishTime": "2022-03-17T14:23:20+05:30",
+				"StartTime":  "2022-03-17T14:22:20Z",
+				"FinishTime": "2022-03-17T14:23:20Z",
 			},
 			nil,
 			[]string{},
@@ -108,7 +526,7 @@ func TestFilterLogs(t *testing.T) {
 			map[string]string{
 				"Maxlogs":  "-2",
 			},
-			errors.New("invalid max logs limit value, please enter a valid integer from 0 to 1000"),
+			logs.InvalidLimit(),
 			[]string{},
 		},
 	}
@@ -117,31 +535,14 @@ func TestFilterLogs(t *testing.T) {
 		t.Log("Running:", tt.TestName)
 		repository := esRepository
 		params := logs.Parameters{}
-		for k, v := range tt.TestParams {
-			switch k {
-			case "Namespace":
-				params.Namespace = v
-			case "Index":
-				params.Index = v
-			case "Podname":
-				params.Podname = v
-			case "StartTime":
-				params.StartTime = v
-			case "FinishTime":
-				params.FinishTime = v
-			case "Level":
-				params.Level = v
-			case "Maxlogs":
-				params.MaxLogs = v
-			}
-		}
+		addParams(&params,tt.TestParams)
 		logList, err := repository.FilterLogs(params)
 		if err == nil && tt.TestError != nil {
-			t.Errorf("Expected error is %v, found %v", tt.TestError, err)
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
 		} else if err != nil && tt.TestError == nil {
-			t.Errorf("Expected error is %v, found %v", tt.TestError, err)
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
 		} else if err != nil && tt.TestError != nil && err.Error() != tt.TestError.Error() {
-			t.Errorf("Expected error is %v, found %v", tt.TestError, err)
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
 		} else if logList != nil {
 			if strings.Contains(tt.TestName, "Invalid") || strings.Contains(tt.TestName, "No logs") {
 				if !strings.Contains(logList[0], "No logs are present or the entry does not exist") {
@@ -155,9 +556,122 @@ func TestFilterLogs(t *testing.T) {
 				}
 			}
 		}
-
 	}
 }
+
+func TestLogs(t *testing.T) {
+	tests := []struct {
+		TestName     string
+		ShouldFail   bool
+		TestParams   map[string]string
+		TestError    error
+		TestKeywords []string
+	}{
+		{
+			"Filter by no parameters",
+			false,
+			map[string]string{},
+			nil,
+			[]string{"index", "_id", "_source", "level"},
+		},
+		{
+			"Filter by time",
+			false,
+			map[string]string{"StartTime": "2021-03-18T06:41:51.83503Z", "FinishTime": "2021-03-18T06:41:51.83503Z"},
+			nil,
+			[]string{"timestamp", "2021-03-18T06:41:51"},
+		},
+		{
+			"Filter by Logging level, limitting number of logs to 10",
+			false,
+			map[string]string{
+				"Level":"unknown",
+				"Maxlogs":"10",
+			},
+			nil,
+			[]string{"unknown"},
+		},
+		{
+			"Invalid timestamp",
+			false,
+			map[string]string{
+				"StartTime":  "hey",
+				"FinishTime": "hey",
+			},
+			logs.InvalidTimeStamp(),
+			[]string{},
+		},
+		{
+			"No logs in the given time interval",
+			false,
+			map[string]string{
+				"StartTime":  "2022-03-17T14:22:20Z",
+				"FinishTime": "2022-03-17T14:23:20Z",
+			},
+			nil,
+			[]string{},
+		},
+		{
+			"Negative maxlogs",
+			false,
+			map[string]string{
+				"Maxlogs":  "-2",
+			},
+			logs.InvalidLimit(),
+			[]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Log("Running:", tt.TestName)
+		repository := esRepository
+		params := logs.Parameters{}
+		addParams(&params,tt.TestParams)
+		logList, err := repository.FilterLogs(params)
+		if err == nil && tt.TestError != nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError == nil {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if err != nil && tt.TestError != nil && err.Error() != tt.TestError.Error() {
+			t.Errorf("Expected error is: %v, found %v", tt.TestError, err)
+		} else if logList != nil {
+			if strings.Contains(tt.TestName, "Invalid") || strings.Contains(tt.TestName, "No logs") {
+				if !strings.Contains(logList[0], "No logs are present or the entry does not exist") {
+					t.Errorf("Expected response: No logs are present or the entry does not exist")
+				}
+			} else {
+				for _, keyword := range tt.TestKeywords {
+					if !strings.Contains(logList[0], keyword) {
+						t.Errorf("Invalid logs found!")
+					}
+				}
+			}
+		}
+	}
+}
+func addParams(params *logs.Parameters, testParams map[string]string) {
+	for k, v := range testParams {
+		switch k {
+		case "ContainerName":
+			params.ContainerName = v
+		case "Namespace":
+			params.Namespace = v
+		case "Index":
+			params.Index = v
+		case "Podname":
+			params.Podname = v
+		case "StartTime":
+			params.StartTime = v
+		case "FinishTime":
+			params.FinishTime = v
+		case "Level":
+			params.Level = v
+		case "Maxlogs":
+			params.MaxLogs = v
+		}
+	}
+}
+
 
 func initCustomZapLogger(level string) (*zap.Logger, error) {
 	lv := zap.AtomicLevel{}

--- a/test/e2e/populate_indices.sh
+++ b/test/e2e/populate_indices.sh
@@ -130,7 +130,7 @@ check_elasticdump(){
 }
 
 populate_es(){
-  NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump \
+  NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/.bin/elasticdump \
     --output=http://localhost:9200 \
     --input=test-logs-mapping.json \
     --type=data

--- a/test/e2e/populate_indices.sh
+++ b/test/e2e/populate_indices.sh
@@ -11,6 +11,7 @@ insert_infra() {
       "properties": {
         "docker.container_id":{"type":"keyword"},
         "kubernetes.namespace_name": { "type": "keyword" },
+        "kubernetes.container_name":{"type":"text","fields":{"raw":{"type":"keyword"}}},
         "kubernetes.pod_name": { "type": "keyword" },
         "kubernetes.host" : {"type":"keyword"},
         "kubernetes.pod_id" : {"type":"keyword"},
@@ -42,6 +43,7 @@ insert_app() {
       "properties": {
         "docker.container_id":{"type":"keyword"},
         "kubernetes.namespace_name": { "type": "keyword" },
+        "kubernetes.container_name":{"type":"text","fields":{"raw":{"type":"keyword"}}},
         "kubernetes.pod_name": { "type": "keyword" },
         "kubernetes.host" : {"type":"keyword"},
         "kubernetes.pod_id" : {"type":"keyword"},
@@ -73,6 +75,7 @@ insert_audit() {
       "properties": {
         "docker.container_id":{"type":"keyword"},
         "kubernetes.namespace_name": { "type": "keyword" },
+        "kubernetes.container_name":{"type":"text","fields":{"raw":{"type":"keyword"}}},
         "kubernetes.pod_name": { "type": "keyword" },
         "kubernetes.host" : {"type":"keyword"},
         "kubernetes.pod_id" : {"type":"keyword"},
@@ -127,7 +130,7 @@ check_elasticdump(){
 }
 
 populate_es(){
-  NODE_TLS_REJECT_UNAUTHORIZED=0 ./node_modules/.bin/elasticdump \
+  NODE_TLS_REJECT_UNAUTHORIZED=0 elasticdump \
     --output=http://localhost:9200 \
     --input=test-logs-mapping.json \
     --type=data


### PR DESCRIPTION
Related Ticket - [https://issues.redhat.com/browse/LOG-1435](url)
Added Relevant Endpoints With Unit Tests, and E2E tests
-> `GET /logs?starttime=0&endtime=0?&limit=100&level=debug`
-> `GET /logs/namespace/{namespace}?starttime=0&endtime=0?&limit=100&level=debug`
-> `GET /logs/namespace/{namespace}/pod/{podname}?starttime=0&endtime=0?&limit=100&level=debug`
-> `GET /logs/namespace/{namespace}/pod/{podname}/container/{containername}?starttime=0&endtime=0?&limit=100&level=debug`
-> `GET /logs/bylabels/<k1=val1>,<k2=val2>...?starttime=0&endtime=0?&limit=100&level=debug`
-> `GET /logs/namespace/{namespace}/entity/{entity}?starttime=0&endtime=0?&limit=100&level=debug` [To be implemented]
